### PR TITLE
Move virtual serial ports docs to own page

### DIFF
--- a/docs/guide-testing.md
+++ b/docs/guide-testing.md
@@ -17,21 +17,3 @@ const port = new SerialPort('/dev/ROBOT')
 ```
 
 The code can be found in the [`@serialport/binding-mock`](api-binding-mock.md) package.
-
-## Virtual Serial Ports
-
-Sometimes you need to develope and test your software without being able to use a real serial port or without having access to the target device. In those situations you can use virtual serial ports.
-
-### Free Virtual Serial Ports
-
-On Windows you can use e.g. [Free* Virtual Serial Ports](https://freevirtualserialports.com/) to create virtual ports and then [Free* Serial Analyzer](https://freeserialanalyzer.com/) to view and monitor the port traffic.
-
-**Free meaning trial mode in this case*
-
-Use the "Create New Bridge" feature to create two virtual serial ports which then are linked together (you can even configure the wiring between the ports if you need).
-
-![free virtual serial ports screenshot](/img/free-virtual-serial-ports.png)
-
-After you have bridged your new virtual ports e.g. COM5 and COM6, you are able to write data to COM5 port and monitor the traffic from port COM6 with the Free Serial Analyzer.
-
-![free serial analyzer screenshot](/img/free-serial-analyzer.png)

--- a/docs/guide-virtual-serial-ports.md
+++ b/docs/guide-virtual-serial-ports.md
@@ -1,0 +1,20 @@
+---
+id: guide-virtual-serial-ports
+title: Virtual Serial Ports
+---
+
+Sometimes you need to develope and test your software without being able to use a real serial port or without having access to the target device. In those situations you can use virtual serial ports.
+
+### Free Virtual Serial Ports
+
+On Windows you can use e.g. [Free* Virtual Serial Ports](https://freevirtualserialports.com/) to create virtual ports and then [Free* Serial Analyzer](https://freeserialanalyzer.com/) to view and monitor the port traffic.
+
+**Free meaning trial mode in this case*
+
+Use the "Create New Bridge" feature to create two virtual serial ports which then are linked together (you can even configure the wiring between the ports if you need).
+
+![free virtual serial ports screenshot](/img/free-virtual-serial-ports.png)
+
+After you have bridged your new virtual ports e.g. COM5 and COM6, you are able to write data to COM5 port and monitor the traffic from port COM6 with the Free Serial Analyzer.
+
+![free serial analyzer screenshot](/img/free-serial-analyzer.png)

--- a/packages/website/i18n/en.json
+++ b/packages/website/i18n/en.json
@@ -74,6 +74,9 @@
       "guide-usage": {
         "title": "SerialPort Usage"
       },
+      "guide-virtual-serial-ports": {
+        "title": "Virtual Serial Ports"
+      },
       "version-7.x.x/version-7.x.x-api-binding-abstract": {
         "title": "Abstract Binding"
       },

--- a/packages/website/pages/en/versions.js
+++ b/packages/website/pages/en/versions.js
@@ -36,7 +36,7 @@ function Versions(props) {
                 <td>
                   {/* You are supposed to change this href where appropriate
                         Example: href="<baseUrl>/docs(/:language)/:id" */}
-                  <a href={`${siteConfig.baseUrl}${siteConfig.docsUrl}/${props.language ? `${props.language}/` : ''}/guide-about`}>Documentation</a>
+                  <a href={`${siteConfig.baseUrl}${siteConfig.docsUrl}/${props.language ? `${props.language}/` : ''}guide-about`}>Documentation</a>
                 </td>
                 <td>
                   <a href="">Release Notes</a>

--- a/packages/website/sidebars.json
+++ b/packages/website/sidebars.json
@@ -1,7 +1,14 @@
 {
   "guides": {
     "Getting Started": ["guide-about", "guide-platform-support", "guide-installation"],
-    "Usage": ["guide-usage", "guide-cli", "guide-debugging", "guide-errors", "guide-testing"],
+    "Usage": [
+      "guide-usage",
+      "guide-cli",
+      "guide-debugging",
+      "guide-errors",
+      "guide-testing",
+      "guide-virtual-serial-ports"
+    ],
     "API Core": ["api-serialport"],
     "API Bindings": ["api-bindings", "api-binding-mock", "api-binding-abstract"],
     "API Interfaces": ["api-stream"],


### PR DESCRIPTION
- Move virtual serial ports guide to own page
- Fix minor unrelated broken URL (noticed during testing)

Changes as suggested by @reconbot in #6.