### PR TITLE
/docs: Misc typo fixes and rewordings/markup for clarity

### DIFF
--- a/docs/api-binding-abstract.md
+++ b/docs/api-binding-abstract.md
@@ -13,7 +13,8 @@ class AbstractBinding {
   constructor(opt: OpenOptions)
 
   /**
-   * Opens a connection to the serial port referenced by the path. Promise resolves after the port is opened, configured and ready for use.
+   * Opens a connection to the serial port referenced by the path. Promise resolves after the port
+   * is opened, configured and ready for use.
    * @param {string} path the path or com port to open
    * @param {openOptions} options openOptions for the serialport
    * @returns {Promise} Resolves after the port is opened and configured.
@@ -26,9 +27,12 @@ class AbstractBinding {
   close(): Promise<void>
 
   /**
-   * Request a number of bytes from the SerialPort. This function is similar to Node's [`fs.read`](http://nodejs.org/api/fs.html#fs_fs_read_fd_buffer_offset_length_position_callback) except it will always return at least one byte.
+   * Request a number of bytes from the SerialPort. This function is similar to Node's
+   * [`fs.read`](http://nodejs.org/api/fs.html#fs_fs_read_fd_buffer_offset_length_position_callback)
+   * except it will always return at least one byte.
 
-The in progress reads must error when the port is closed with an error object that has the property `canceled` equal to `true`. Any other error will cause a disconnection.
+   * The in progress reads must error when the port is closed with an error object that has the
+   * property `canceled` equal to `true`. Any other error will cause a disconnection.
 
    * @param {buffer} buffer Accepts a [`Buffer`](http://nodejs.org/api/buffer.html) object.
    * @param {integer} offset The offset in the buffer to start writing at.
@@ -40,7 +44,8 @@ The in progress reads must error when the port is closed with an error object th
   /**
    * Write bytes to the SerialPort. Only called when there is no pending write operation.
 
-The in progress writes must error when the port is closed with an error object that has the property `canceled` equal to `true`. Any other error will cause a disconnection.
+   * The in-progress writes must error when the port is closed, with an error object that has the
+   * property `canceled` equal to `true`. Any other error will cause a disconnection.
 
    * @param {buffer} buffer - Accepts a [`Buffer`](http://nodejs.org/api/buffer.html) object.
    * @returns {Promise} Resolves after the data is passed to the operating system for writing.
@@ -55,7 +60,8 @@ The in progress writes must error when the port is closed with an error object t
 
   /**
    * Set control flags on an open port.
-   * @param {object=} options All options are operating system default when the port is opened. Every flag is set on each call to the provided or default values. All options are always provided.
+   * @param {object=} options All options are operating system default when the port is opened. 
+   * Every flag is set on each call to the provided or default values. All options are always provided.
    * @param {Boolean} [options.brk=false] flag for brk
    * @param {Boolean} [options.cts=false] flag for cts
    * @param {Boolean} [options.dsr=false] flag for dsr
@@ -83,7 +89,8 @@ The in progress writes must error when the port is closed with an error object t
   flush(): Promise<void>
 
   /**
-   * Drain waits until all output data is transmitted to the serial port. An in progress write should be completed before this returns.
+   * Drain waits until all output data is transmitted to the serial port. An in-progress write
+   * should be completed before this returns.
    * @returns {Promise} Resolves once the drain operation finishes.
    */
   drain(): Promise<void>

--- a/docs/api-binding-mock.md
+++ b/docs/api-binding-mock.md
@@ -8,7 +8,7 @@ new MockBinding(options: OpenOptions)
 ```
 
 
-Testing is an important feature of any library. To aid in our own tests we've developed a `MockBinding` a fake hardware binding that doesn't actually need any hardware to run. This class passes all of the same tests as our hardware based bindings and provides a few additional test related interfaces.
+Testing is an important feature of any library. To aid in our own tests, we've developed a `MockBinding`, a fake hardware binding that doesn't actually need any hardware to run. This class passes all of the same tests as our hardware based bindings and provides a few additional test related interfaces.
 
 ### Example
 
@@ -56,7 +56,7 @@ class MockBinding extends AbstractBinding {
   // Emit data on a mock port
   emitData(data: Buffer | string | number[])
 
-// Standard bindings interface
+  // Standard bindings interface
   open(path: string, opt: OpenOpts): Promise<void>
   close(): Promise<void>
   read(buffer: Buffer, offset: number, length: number): Promise<Buffer>

--- a/docs/api-bindings.md
+++ b/docs/api-bindings.md
@@ -3,14 +3,14 @@ id: api-bindings
 title: Bindings
 ---
 
-The `Binding` is how Node-SerialPort talks to the underlying system. By default, we auto detect Windows, Linux and OS X, and load the appropriate module for your system. You can assign `SerialPort.Binding` to any binding you like. Find more by searching ["serialport-binding" at npm](https://www.npmjs.com/search?q=serialport-binding).
+The `Binding` is how Node-SerialPort talks to the underlying system. By default, we auto-detect Windows, Linux and OS X, and load the appropriate module for your system. You can assign `SerialPort.Binding` to any binding you like. Find more bindings by searching ["serialport-binding" at npm](https://www.npmjs.com/search?q=serialport-binding).
 
-You can prevent auto loading the default bindings by requiring the [SerialPort Stream](api-stream.md) package.
+You can prevent auto-loading of the default bindings by requiring the [SerialPort Stream](api-stream.md) package.
   ```js
   var SerialPort = require('@serialport/stream');
   SerialPort.Binding = MyBindingClass;
   ```
 
-You never have to use `Binding` objects directly. `@serialPort/stream` uses them to access the underlying hardware. This documentation is geared towards people who are making bindings for different platforms. The `AbstractBinding` class from the [`@serialport/binding-abstract`](api-binding-abstract.md) package can be inherited from to get the base api.
+You never have to use `Binding` objects directly. `@serialPort/stream` uses them to access the underlying hardware. This documentation is geared towards people who are making bindings for different platforms. The `AbstractBinding` class from the [`@serialport/binding-abstract`](api-binding-abstract.md) package can be inherited to get the base API.
 
 There is also a [`MockBinding`](api-binding-mock.md) package to assist with testing.

--- a/docs/api-parser-delimiter.md
+++ b/docs/api-parser-delimiter.md
@@ -9,7 +9,7 @@ new Delimiter(options: { delimiter: string | Buffer | number[] })
 A transform stream that emits data each time a byte sequence is received. To use the `Delimiter` parser, provide a delimiter as a string, buffer, or array of bytes. Runs in O(n) time.
 
 Arguments
-- `options.delimiter: string|Buffer|number[]` The delimiter in which to split incoming data.
+- `options.delimiter: string|Buffer|number[]` The delimiter on which to split incoming data.
 
 
 ```js

--- a/docs/api-parser-inter-byte-timeout.md
+++ b/docs/api-parser-inter-byte-timeout.md
@@ -7,11 +7,11 @@ new InterByteTimeout(options)
 ```
 Emits data if there is a pause between packets for the specified amount of time.
 
-A transform stream that emits data as a buffer after not recieving any bytes for the specified amount of time.
+A transform stream that emits data as a buffer after not receiving any bytes for the specified amount of time.
 
 Arguments
-- `options.interval: number` the period of silence in milliseconds after which data is emited
-- `options.maxBufferSize: number` the maximum number of bytes after which data will be emited. Defaults to 65536.
+- `options.interval: number` the period of silence in milliseconds after which data is emitted.
+- `options.maxBufferSize: number` the maximum number of bytes after which data will be emitted. Defaults to 65536.
 
 ## Example
 ```js
@@ -20,3 +20,4 @@ const InterByteTimeout = require('@serialport/parser-inter-byte-timeout')
 const port = new SerialPort('/dev/tty-usbserial1')
 const parser = port.pipe(new InterByteTimeout({interval: 30}))
 parser.on('data', console.log) // will emit data if there is a pause between packets of at least 30ms
+```

--- a/docs/api-parser-ready.md
+++ b/docs/api-parser-ready.md
@@ -7,7 +7,7 @@ new Ready(options)
 ```
 A transform stream that waits for a sequence of "ready" bytes before emitting a ready event and emitting data events
 
-To use the `Ready` parser provide a byte start sequence. After the bytes have been received a ready event is fired and data events are passed through.
+To use the `Ready` parser provide a byte start sequence. After the bytes have been received, a ready event is fired and data events are passed through.
 
 Arguments
 - `options.delimiter?: string` delimiter to use to detect the input is ready

--- a/docs/api-parser-regex.md
+++ b/docs/api-parser-regex.md
@@ -7,11 +7,11 @@ new Regex(options)
 ```
 A transform stream that uses a regular expression to split the incoming text upon.
 
-To use the `Regex` parser provide a regular expression to split the incoming text upon. Data is emitted as string controllable by the `encoding` option (defaults to `utf8`).
+To use the `Regex` parser provide a regular expression to split the incoming text upon. Data is emitted as a string controllable by the `encoding` option (defaults to `utf8`).
 
 Arguments
-- `options.regex: RegExp` the regular expression to use to split incoming text
-- `options.encoding?: string` text encoding for the stream
+- `options.regex: RegExp` The regular expression to use to split incoming text
+- `options.encoding?: string` Text encoding for the stream
 
 ```js
 const SerialPort = require('serialport')

--- a/docs/api-parsers-overview.md
+++ b/docs/api-parsers-overview.md
@@ -3,7 +3,7 @@ id: api-parsers-overview
 title: What are Parsers?
 ---
 
-Parsers are collection of transform streams to processes incoming data
+Parsers are collections of transform streams to processes incoming data
 
 The default `Parsers` are [Transform streams](https://nodejs.org/api/stream.html#stream_class_stream_transform) that process incoming data. To use the parsers, you must create them and then pipe the Serialport to the parser. Be careful to only write to the SerialPort object and not the parser.
 

--- a/docs/api-serialport.md
+++ b/docs/api-serialport.md
@@ -11,7 +11,7 @@ This package provides everything you need to start talking over your serialport.
 
 > Most of the api is covered in the [Stream Interface](api-stream.md) docs.
 
-Historically this was the only package involved and it contained everything. Since version 7 the internals have been split into their own modules and be required separately allowing a user to only install what they require.
+Historically this was the only package involved and it contained everything. Since version 7 the internals have been split into their own modules and can be required separately, allowing a user to only install what they need.
 
 This allows for smaller installs and alternative interfaces, bindings and parsers.
 

--- a/docs/api-stream.md
+++ b/docs/api-stream.md
@@ -7,9 +7,9 @@ title: Stream Interface
 const SerialPort = require('@serialport/stream')
 ```
 
-This is the Node.js Stream Interface for SerialPort. For more information on Node.js Streams please see their [Stream API docs](https://nodejs.org/api/stream.html) and google for a large number of tutorials on Node.js streams. This stream is a Duplex Stream allowing for reading and writing. It has additional methods for managing the SerialPort connection.
+This is the Node.js Stream Interface for SerialPort (for more information on Node.js Streams, please see the [Stream API docs](https://nodejs.org/api/stream.html) or one of the numerous independent tutorials). This stream is a Duplex Stream allowing for reading and writing. It has additional methods for managing the SerialPort connection.
 
-You also get the stream interface by requiring the [`serialport`](api-serialport.md) package which comes with a default set of Bindings and Parsers.
+You also get the stream interface by requiring the [`serialport`](api-serialport.md) package, which comes with a default set of Bindings and Parsers.
 
 ```js
 // To get a default set of Bindings and Parsers
@@ -69,7 +69,7 @@ SerialPort.Binding: Binding
 
 The hardware access binding. `Bindings` are how Node-Serialport talks to the underlying system. This static property is used to set the default binding for any new port created with this constructor. It is also used for `Serialport.list`.
 
-If you're using the `serialport` package this defaults to `require('@serialport/bindings')`.
+If you're using the `serialport` package, this defaults to `require('@serialport/bindings')`.
 
 ## Static Methods
 
@@ -77,14 +77,14 @@ If you're using the `serialport` package this defaults to `require('@serialport/
 ```typescript
 SerialPort.list(): Promise<PortInfo[]>
 ```
-Retrieves a list of available serial ports with metadata. Only the `path` is guaranteed. If unavailable the other fields will be undefined. The `path` is either the path or an identifier (eg `COM1`) used to open the SerialPort.
+Retrieves a list of available serial ports with metadata. Only the `path` is guaranteed (other fields will be undefined if unavailable). The `path` is either the path or an identifier (eg `COM1`) used to open the SerialPort.
 
 The `SerialPort` class delegates this function to the provided `Binding` on [`SerialPort.Binding`](#serialportbinding-binding).
 
-We make an effort to identify the hardware attached and have consistent results between systems. Linux and OS X are mostly consistent. Windows relies on 3rd party device drivers for the information and is unable to guarantee the information. On windows If you have a USB connected device can we provide a serial number otherwise it will be `undefined`. The `pnpId` and `locationId` are not the same or present on all systems. The examples below were run with the same Arduino Uno.
+We make an effort to identify the hardware attached and have consistent results between systems. Linux and OS X are mostly consistent. Windows relies on 3rd-party device drivers for this information and is unable to guarantee the accuracy. If you have a USB-connected device, we provide a serial number - otherwise it will be `undefined`. The `pnpId` and `locationId` are not the same or present on all systems. The examples below were run with the same Arduino Uno.
 
 :::note
-In `serialport@8` and `@serialport/bindings@3` We renamed `PortInfo.comName` to `PortInfo.path` if you use comName you'll get a warning until the next major release.
+In `serialport@8` and `@serialport/bindings@3` we renamed `PortInfo.comName` to `PortInfo.path`. If you use comName you'll get a warning until the next major release.
 :::
 
 ```js
@@ -167,10 +167,10 @@ The `open` event happens when the port is opened and ready for writing. This hap
 The `error` provides an error object whenever there is an unhandled error. You can usually handle an error with a callback to the method that produced it.
 
 ### `close`
-The `close` event's is emitted when the port is closed. In the case of a disconnect it will be called with a Disconnect Error object (`err.disconnected == true`). In the event of a close error (unlikely), an error event is triggered.
+The `close` event is emitted when the port is closed. In the case of a disconnect, it will be called with a Disconnect Error object (`err.disconnected == true`). In the event of an error while closing (unlikely), an error event is triggered.
 
 ### `data`
-Listening for the `data` event puts the port in flowing mode. Data is emitted as soon as it's received. Data is a `Buffer` object with any amount of data in it. It's only guaranteed to have at least one byte. See the [parsers](api-parsers-overview.md) section for more information on how to work with the data, and the [Node.js stream documentation](https://nodejs.org/api/stream.html#stream_event_data) for more information on the data event.
+Listening for the `data` event puts the port in flowing mode. Data is emitted as soon as it's received. Data is a `Buffer` object with any amount of data in it. The buffer is only guaranteed to have at least one byte. See the [parsers](api-parsers-overview.md) section for more information on how to work with the data, and the [Node.js stream documentation](https://nodejs.org/api/stream.html#stream_event_data) for more information on the data event.
 
 ### `drain`
 The `drain` event is emitted when it is performant to write again if a `write()` call has returned `false`. For more info see the [Node.js `drain` documentation](https://nodejs.org/api/stream.html#stream_event_drain) for more info.
@@ -201,16 +201,16 @@ serialport.write(data: string|Buffer|Array<number>, encoding?: string, callback?
 
 Writes data to the given serial port. Buffers written data if the port is not open and writes it after the port opens. The write operation is non-blocking. When it returns, data might still not have been written to the serial port. See `drain()`.
 
-> Some devices, like the Arduino, reset when you open a connection to them. In such cases, immediately writing to the device will cause lost data as they wont be ready to receive the data. This is often worked around by having the Arduino send a "ready" byte that your Node program waits for before writing. You can also often get away with waiting around 400ms. See the `ReadyParser` for a solution to this.
+> Some devices, like the Arduino, reset when you open a connection to them. In such cases, immediately writing to the device will cause transmitted data to be lost as the devices won't be ready to receive the data. This is often worked around by having the Arduino send a "ready" byte that your Node program awaits before writing. You can also often get away with waiting a set amount, around 400ms. See the `ReadyParser` for a solution to this.
 
-If a port is disconnected during a write, the write will error in addition to the `close` event.
+If a port is disconnected during a write, the write will produce an error in addition to the `close` event.
 
-From the [stream docs](https://nodejs.org/api/stream.html#stream_writable_write_chunk_encoding_callback) write errors don't always provide the error in the callback, sometimes they use the error event.
+According to the [stream docs](https://nodejs.org/api/stream.html#stream_writable_write_chunk_encoding_callback), write errors don't always provide the error in the callback; sometimes they use the error event.
 > If an error occurs, the callback may or may not be called with the error as its first argument. To reliably detect write errors, add a listener for the 'error' event.
 
-While this is in the stream docs, this hasn't been observed.
+While this is in the stream docs, it hasn't been observed.
 
-In addition to the usual `stream.write` arguments (`String` and `Buffer`), `write()` can accept arrays of bytes (positive numbers under 256) which is passed to `Buffer.from([])` for conversion. This extra functionality is pretty sweet.
+In addition to the usual `stream.write` arguments (`String` and `Buffer`), `write()` can accept an array of bytes (positive numbers under 256) which is passed to `Buffer.from([])` for conversion.
 
 Arguments:
 
@@ -218,7 +218,7 @@ Arguments:
 - `encoding?: string` The encoding, if chunk is a string. Defaults to `'utf8'`. Also accepts `'ascii'`, `'base64'`, `'binary'`, and `'hex'` See [Buffers and Character Encodings](https://nodejs.org/api/buffer.html#buffer_buffers_and_character_encodings) for all available options.
 - `callback?: error => {}` Called once the write operation finishes. Data may not yet be drained to the underlying port.
 
-Returns a boolean `false` if the stream wishes for the calling code to wait for the `drain` event to be emitted before continuing to write additional data; otherwise `true`.
+Returns `false` if the stream wishes for the calling code to wait for the `drain` event to be emitted before continuing to write additional data; otherwise `true`.
 
 ### `SerialPort#read`
 ```js
@@ -234,7 +234,7 @@ Arguments:
 ```js
 serialport.close(callback?: error => {}): void
 ```
-Closes an open connection. If there are in progress writes when the port is closed the writes will error.
+Closes an open connection. If there are in-progress writes when the port is closed the writes will error.
 
 Arguments:
 - `callback?: (error => {}: void) Called once a connection is closed.
@@ -246,7 +246,7 @@ serialport.set(options: setOptions, callback?: error => {}): void
 Set control flags on an open port. Uses [`SetCommMask`](https://msdn.microsoft.com/en-us/library/windows/desktop/aa363257(v=vs.85).aspx) for Windows and [`ioctl`](http://linux.die.net/man/4/tty_ioctl) for OS X and Linux.
 
 Arguments:
-- `options: setOptions` All options are operating system default when the port is opened. Every flag is set on each call to the provided or default values. If options isn't provided default options are used.
+- `options: setOptions` All options default to the operating system defaults when the port is opened. Every flag is set on each call to the provided or default values.
 - `callback: error => {}` Called once the port's flags have been set.
 
 `setOptions`
@@ -280,7 +280,7 @@ Returns the control flags (CTS, DSR, DCD) on the open port. Uses [`GetCommModemS
 ```typescript
 serialport.flush(callback? error => {}):void
 ```
-Flush discards data received but not read, and written but not transmitted by the operating system. For more technical details, see [`tcflush(fd, TCIOFLUSH)`](http://linux.die.net/man/3/tcflush) for Mac/Linux and [`FlushFileBuffers`](http://msdn.microsoft.com/en-us/library/windows/desktop/aa364439) for Windows.
+Flush discards data that has been received but not read, or written but not transmitted by the operating system. For more technical details, see [`tcflush(fd, TCIOFLUSH)`](http://linux.die.net/man/3/tcflush) for Mac/Linux and [`FlushFileBuffers`](http://msdn.microsoft.com/en-us/library/windows/desktop/aa364439) for Windows.
 
 - `callback? error => {}` Called once the flush operation finishes.
 
@@ -289,7 +289,7 @@ Flush discards data received but not read, and written but not transmitted by th
 ```typescript
 serialport.drain(callback? error => {}):void
 ```
-Waits until all output data is transmitted to the serial port. After any pending write has completed it calls [`tcdrain()`](http://linux.die.net/man/3/tcdrain) or [FlushFileBuffers()](https://msdn.microsoft.com/en-us/library/windows/desktop/aa364439(v=vs.85).aspx) to ensure it has been written to the device.
+Waits until all output data is transmitted to the serial port. After any pending write has completed, it calls [`tcdrain()`](http://linux.die.net/man/3/tcdrain) or [FlushFileBuffers()](https://msdn.microsoft.com/en-us/library/windows/desktop/aa364439(v=vs.85).aspx) to ensure it has been written to the device.
 
 - `callback? error => {}` Called once the drain operation returns.
 

--- a/docs/code-of-conduct.md
+++ b/docs/code-of-conduct.md
@@ -3,7 +3,7 @@ id: code-of-conduct
 title: Code of Conduct
 ---
 
-SerialPort follows the Nodebots Code of Conduct. The full text can be found at [nodebots.io](http://nodebots.io/conduct.html).
+SerialPort follows the NodeBots Code of Conduct. The full text can be found at [nodebots.io](http://nodebots.io/conduct.html).
 
 ## TLDR
 - Be respectful.

--- a/docs/guide-cli.md
+++ b/docs/guide-cli.md
@@ -3,7 +3,7 @@ id: guide-cli
 title: Command Line Tools
 ---
 
-(These cli tools were formally part of the `serialport` package and have now been moved to their own packages for ease of use.)
+(These cli tools were formerly part of the `serialport` package and have now been moved to their own packages for ease of use.)
 
 All cli tools can be run via [`npx`](https://www.npmjs.com/package/npx) or installed globally.
 

--- a/docs/guide-installation.md
+++ b/docs/guide-installation.md
@@ -161,4 +161,4 @@ npm install serialport --build-from-source
 
 Node-gyp's documentation doesn't mention it, but it sometimes helps to create a C++ project in [Visual Studio](https://www.visualstudio.com/) so that it will install any necessary components not already installed during the past two hours of setup. This will solve some instances of `Failed to locate: "CL.exe"`.
 
-An old issue that you may still run into. When working with multiple Serial Ports you can set the `UV_THREADPOOL_SIZE` environment variable to be set to 1 + the number of ports you wish to open at a time. (Defaults to `4` which supports 3 open ports).
+An old issue that you may still run into: when working with multiple Serial Ports you can set the `UV_THREADPOOL_SIZE` environment variable to be set to 1 + the number of ports you wish to open at a time. Defaults to `4` which supports 3 open ports.

--- a/docs/guide-usage.md
+++ b/docs/guide-usage.md
@@ -15,7 +15,7 @@ When opening a serial port, specify (in this order)
 1. Path to Serial Port - required.
 1. Options - optional and described below.
 
-Constructing a `SerialPort` object immediately opens a port. While you can read and write at any time (it will be queued until the port is open), most port functions require an open port. There are three ways to detect when a port is opened.
+Constructing a `SerialPort` object immediately opens a port. While you can read and write at any time (actions will be queued until the port is open), most port functions require an open port. There are three ways to detect when a port is opened.
 
 - The `open` event is always emitted when the port is opened.
 - The constructor's openCallback is passed to `.open()`, if you haven't disabled the `autoOpen` option. If you have disabled it, the callback is ignored.
@@ -38,7 +38,7 @@ port.on('error', function(err) {
 })
 ```
 
-Detecting open errors can be moved to the constructor's callback.
+Detecting open-related errors can be moved to the constructor's callback.
 ```js
 const SerialPort = require('serialport')
 const port = new SerialPort('/dev/tty-usbserial1', function (err) {
@@ -58,7 +58,7 @@ port.write('main screen turn on', function(err) {
 
 ## Auto Open
 
-When disabling the `autoOpen` option you'll need to open the port on your own.
+If you disable the `autoOpen` option, you'll need to open the port on your own.
 
 ```js
 const SerialPort = require('serialport')
@@ -81,7 +81,7 @@ port.on('open', function() {
 
 ## Reading Data
 
-Get updates of new data from the serial port as follows:
+Get updates about new data arriving through the serial port as follows:
 
 ```js
 // Read data that is available but keep the stream in "paused mode"
@@ -98,7 +98,7 @@ port.on('data', function (data) {
 const lineStream = port.pipe(new Readline())
 ```
 
-You can write to the serial port by sending a string or buffer to the write method:
+You can write to the serial port by sending a string or buffer to the `write` method:
 
 ```js
 port.write('Hi Mom!')


### PR DESCRIPTION
Minor copy edits, also split some block comments into more lines so that the code boxes don't overflow. Adjustments welcome!