### PR TITLE
Update api-parser-cctalk.md

### DIFF
--- a/versioned_docs/version-8.x.x/api-parser-cctalk.md
+++ b/versioned_docs/version-8.x.x/api-parser-cctalk.md
@@ -13,6 +13,6 @@ const SerialPort = require('serialport')
 const CCTalk = require('@serialport/parser-cctalk')
 const port = new SerialPort('/dev/ttyUSB0')
 
-const parser = port.pipe(new CCtalk())
+const parser = port.pipe(new CCTalk())
 parser.on('data', console.log)
 ```


### PR DESCRIPTION
CCtalk is not defined may occur if someone copy-pastes the code and tries to run.
typo fix : CCtalk() -> CCTalk()