### PR TITLE
Update flush docs to reflect use of PurgeComm

### DIFF
--- a/docs/api-stream.md
+++ b/docs/api-stream.md
@@ -287,7 +287,7 @@ Returns the control flags (CTS, DSR, DCD) on the open port. Uses [`GetCommModemS
 ```typescript
 serialport.flush(callback? error => {}):void
 ```
-Flush discards data that has been received but not read, or written but not transmitted by the operating system. For more technical details, see [`tcflush(fd, TCIOFLUSH)`](http://linux.die.net/man/3/tcflush) for Mac/Linux and [`FlushFileBuffers`](http://msdn.microsoft.com/en-us/library/windows/desktop/aa364439) for Windows.
+Flush discards data that has been received but not read, or written but not transmitted by the operating system. For more technical details, see [`tcflush(fd, TCIOFLUSH)`](http://linux.die.net/man/3/tcflush) for Mac/Linux and [`PurgeComm`](https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-purgecomm) for Windows.
 
 - `callback? error => {}` Called once the flush operation finishes.
 

--- a/versioned_docs/version-9.x.x/api-stream.md
+++ b/versioned_docs/version-9.x.x/api-stream.md
@@ -287,7 +287,7 @@ Returns the control flags (CTS, DSR, DCD) on the open port. Uses [`GetCommModemS
 ```typescript
 serialport.flush(callback? error => {}):void
 ```
-Flush discards data that has been received but not read, or written but not transmitted by the operating system. For more technical details, see [`tcflush(fd, TCIOFLUSH)`](http://linux.die.net/man/3/tcflush) for Mac/Linux and [`FlushFileBuffers`](http://msdn.microsoft.com/en-us/library/windows/desktop/aa364439) for Windows.
+Flush discards data that has been received but not read, or written but not transmitted by the operating system. For more technical details, see [`tcflush(fd, TCIOFLUSH)`](http://linux.die.net/man/3/tcflush) for Mac/Linux and [`PurgeComm`](https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-purgecomm) for Windows.
 
 - `callback? error => {}` Called once the flush operation finishes.
 


### PR DESCRIPTION
Update to the [doc for serialport flush](https://serialport.io/docs/api-stream#serialportflush) to reflect that on Windows  [PurgeComm](https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-purgecomm) is used instead of FlushFileBuffers?  (FlushFileBuffers only seems to be used for the Drain function)

https://github.com/serialport/node-serialport/blob/0461285f04b93034008cf6c22ac566d0a1a09571/packages/bindings/src/serialport_win.cpp#L936-L944

As discussed in https://github.com/serialport/node-serialport/issues/2263

Signed-off-by: Gareth Hancock <gazhank@gmail.com>