### PR TITLE
Update electron docs for electron-rebuild

### DIFF
--- a/docs/guide-installation.md
+++ b/docs/guide-installation.md
@@ -40,18 +40,19 @@ npm install serialport --build-from-source
 
 [Electron](https://electron.atom.io/) is a framework for creating cross-platform desktop applications. It comes with its own version of the Node.js runtime.
 
-If you require `serialport` as a dependency for an Electron project, you should check the version of Electron you are using.  Each release of Serialport is published with prebuilt support for a large number of environments, you can see the supported environments in the [`assets for our latest release`](https://github.com/serialport/node-serialport/releases/latest).  If you are using an Electron version without a prebuild available then you will need to recompile it.
-
-To recompile `serialport` (or any native Node.js module) for Electron, you can use `electron-rebuild`; You may need to install additional build tools in order to use electron-rebuild in your environment; more info at [Electron's README](https://github.com/electron/electron-rebuild/blob/master/README.md).
+Electron has a different [application binary interface (ABI)](https://en.wikipedia.org/wiki/Application_binary_interface) from Node.js, so it is necessary to make sure the correct ABI version is installed to match the electron version of your project rather that the node.js version installed on your machine.  The easiest way to achieve this is to use electron-rebuild:
 
 1. Run `npm install --save-dev electron-rebuild`
 2. Add `electron-rebuild` to your project's package.json's install hook
 3. Run `npm install`
 
-Alternatively, if you are already using Electron-Builder then you can have it recompile Serialport:
+Each release of Serialport is published with prebuilt support for a large number of environments (and ABI combinations), you can see the supported environments in the [`assets for our latest release`](https://github.com/serialport/node-serialport/releases/latest).  If you are using an environment which doesn't have a prebuild available then you will need to recompile it.
+
+To recompile `serialport` (or any native Node.js module) for Electron, you can use `electron-rebuild`; You may need to install additional build tools in order to use electron-rebuild in your environment; more info at [Electron's README](https://github.com/electron/electron-rebuild/blob/master/README.md).:
 
 1. Add `"buildDependenciesFromSource": true,"npmRebuild": false,` to your project.json's build configuration; more info at [Electron-builder](https://www.electron.build/configuration/configuration).
 
+Additional troubleshooting info for electron can be found within the [electron documentation](https://www.electronjs.org/docs/tutorial/using-native-node-modules#troubleshooting).
 
 #### Invoking SerialPort within the renderer processes
 If you wish to invoke serialport within your renderer processes then you will need to override some of the Electron default settings.
@@ -76,7 +77,7 @@ async function createMainWindow() {
 
 Over time we should migrate away from invocation within the renderer process, but many existing projects still rely on these workarounds.
 
-For an example Electron project, check out [`electron-serialport`](https://github.com/johnny-five-io/electron-serialport).
+For an example Electron project, check out [`electron-serialport`](https://github.com/serialport/electron-serialport).
 
 ### NW.js
 

--- a/versioned_docs/version-9.x.x/guide-installation.md
+++ b/versioned_docs/version-9.x.x/guide-installation.md
@@ -40,18 +40,19 @@ npm install serialport --build-from-source
 
 [Electron](https://electron.atom.io/) is a framework for creating cross-platform desktop applications. It comes with its own version of the Node.js runtime.
 
-If you require `serialport` as a dependency for an Electron project, you should check the version of Electron you are using.  Each release of Serialport is published with prebuilt support for a large number of environments, you can see the supported environments in the [`assets for our latest release`](https://github.com/serialport/node-serialport/releases/latest).  If you are using an Electron version without a prebuild available then you will need to recompile it.
-
-To recompile `serialport` (or any native Node.js module) for Electron, you can use `electron-rebuild`; You may need to install additional build tools in order to use electron-rebuild in your environment; more info at [Electron's README](https://github.com/electron/electron-rebuild/blob/master/README.md).
+Electron has a different [application binary interface (ABI)](https://en.wikipedia.org/wiki/Application_binary_interface) from Node.js, so it is necessary to make sure the correct ABI version is installed to match the electron version of your project rather that the node.js version installed on your machine.  The easiest way to achieve this is to use electron-rebuild:
 
 1. Run `npm install --save-dev electron-rebuild`
 2. Add `electron-rebuild` to your project's package.json's install hook
 3. Run `npm install`
 
-Alternativly, if you are already using Electron-Builder then you can have it recompile Serialport:
+Each release of Serialport is published with prebuilt support for a large number of environments (and ABI combinations), you can see the supported environments in the [`assets for our latest release`](https://github.com/serialport/node-serialport/releases/latest).  If you are using an environment which doesn't have a prebuild available then you will need to recompile it.
+
+To recompile `serialport` (or any native Node.js module) for Electron, you can use `electron-rebuild`; You may need to install additional build tools in order to use electron-rebuild in your environment; more info at [Electron's README](https://github.com/electron/electron-rebuild/blob/master/README.md).:
 
 1. Add `"buildDependenciesFromSource": true,"npmRebuild": false,` to your project.json's build configuration; more info at [Electron-builder](https://www.electron.build/configuration/configuration).
 
+Additional troubleshooting info for electron can be found within the [electron documentation](https://www.electronjs.org/docs/tutorial/using-native-node-modules#troubleshooting).
 
 #### Invoking SerialPort within the renderer processes
 If you wish to invoke serialport within your renderer processes then you will need to override some of the Electron default settings.
@@ -74,9 +75,9 @@ async function createMainWindow() {
 }
 ```
 
-Over time we should migrate away from invokation within the renderer process, but many existing projects still rely on these workarounds.
+Over time we should migrate away from invocation within the renderer process, but many existing projects still rely on these workarounds.
 
-For an example Electron project, check out [`electron-serialport`](https://github.com/johnny-five-io/electron-serialport).
+For an example Electron project, check out [`electron-serialport`](https://github.com/serialport/electron-serialport).
 
 ### NW.js
 


### PR DESCRIPTION
Update to documentation to address issue: https://github.com/serialport/node-serialport/issues/2251

- Changed the wording around electron-rebuild from optional to recommended
- Revised the wording regarding supported environments
- Added a link to the troubleshooting info on the electron website
- Updated/corrected the link to the electron-serial port example

Only updated v9 and current docs.  v7 and 8 are unchanged.

Signed-off-by: Gareth Hancock <gazhank@gmail.com>