### PR TITLE
Update electron-rebuild with win specific info

### DIFF
--- a/docs/guide-installation.md
+++ b/docs/guide-installation.md
@@ -40,15 +40,19 @@ npm install serialport --build-from-source
 
 [Electron](https://electron.atom.io/) is a framework for creating cross-platform desktop applications. It comes with its own version of the Node.js runtime.
 
-Electron has a different [application binary interface (ABI)](https://en.wikipedia.org/wiki/Application_binary_interface) from Node.js, so it is necessary to make sure the correct ABI version is installed to match the electron version of your project rather that the node.js version installed on your machine.  The easiest way to achieve this is to use electron-rebuild:
+Electron has a different [application binary interface (ABI)](https://en.wikipedia.org/wiki/Application_binary_interface) from Node.js, so it is necessary to make sure the correct ABI version is installed to match the electron version of your project, rather than the node.js version installed on your machine.  The easiest way to achieve this is to use electron-rebuild:
 
 1. Run `npm install --save-dev electron-rebuild`
 2. Add `electron-rebuild` to your project's package.json's install hook
 3. Run `npm install`
 
+If you have trouble on Windows, try: `.\node_modules\.bin\electron-rebuild.cmd`
+
 Each release of Serialport is published with prebuilt support for a large number of environments (and ABI combinations), you can see the supported environments in the [`assets for our latest release`](https://github.com/serialport/node-serialport/releases/latest).  If you are using an environment which doesn't have a prebuild available then you will need to recompile it.
 
-To recompile `serialport` (or any native Node.js module) for Electron, you can use `electron-rebuild`; You may need to install additional build tools in order to use electron-rebuild in your environment; more info at [Electron's README](https://github.com/electron/electron-rebuild/blob/master/README.md).:
+To recompile `serialport` (or any native Node.js module) for Electron, you can use `electron-rebuild`.  You may need to install additional build tools in order to use electron-rebuild to recompile for your environment; more info can be found at [Electron's README](https://github.com/electron/electron-rebuild/blob/master/README.md).
+
+Once electron-rebuild, and the required build tools are installed you can configure the recompile process:
 
 1. Add `"buildDependenciesFromSource": true,"npmRebuild": false,` to your project.json's build configuration; more info at [Electron-builder](https://www.electron.build/configuration/configuration).
 

--- a/versioned_docs/version-9.x.x/guide-installation.md
+++ b/versioned_docs/version-9.x.x/guide-installation.md
@@ -40,15 +40,19 @@ npm install serialport --build-from-source
 
 [Electron](https://electron.atom.io/) is a framework for creating cross-platform desktop applications. It comes with its own version of the Node.js runtime.
 
-Electron has a different [application binary interface (ABI)](https://en.wikipedia.org/wiki/Application_binary_interface) from Node.js, so it is necessary to make sure the correct ABI version is installed to match the electron version of your project rather that the node.js version installed on your machine.  The easiest way to achieve this is to use electron-rebuild:
+Electron has a different [application binary interface (ABI)](https://en.wikipedia.org/wiki/Application_binary_interface) from Node.js, so it is necessary to make sure the correct ABI version is installed to match the electron version of your project, rather than the node.js version installed on your machine.  The easiest way to achieve this is to use electron-rebuild:
 
 1. Run `npm install --save-dev electron-rebuild`
 2. Add `electron-rebuild` to your project's package.json's install hook
 3. Run `npm install`
 
+If you have trouble on Windows, try: `.\node_modules\.bin\electron-rebuild.cmd`
+
 Each release of Serialport is published with prebuilt support for a large number of environments (and ABI combinations), you can see the supported environments in the [`assets for our latest release`](https://github.com/serialport/node-serialport/releases/latest).  If you are using an environment which doesn't have a prebuild available then you will need to recompile it.
 
-To recompile `serialport` (or any native Node.js module) for Electron, you can use `electron-rebuild`; You may need to install additional build tools in order to use electron-rebuild in your environment; more info at [Electron's README](https://github.com/electron/electron-rebuild/blob/master/README.md).:
+To recompile `serialport` (or any native Node.js module) for Electron, you can use `electron-rebuild`.  You may need to install additional build tools in order to use electron-rebuild to recompile for your environment; more info can be found at [Electron's README](https://github.com/electron/electron-rebuild/blob/master/README.md).
+
+Once electron-rebuild, and the required build tools are installed you can configure the recompile process:
 
 1. Add `"buildDependenciesFromSource": true,"npmRebuild": false,` to your project.json's build configuration; more info at [Electron-builder](https://www.electron.build/configuration/configuration).
 


### PR DESCRIPTION
A further tweak to the electron-rebuild documentation with windows specific info

Additional bonus content: fixed a typo, and reworded the recompilation process

Signed-off-by: Gareth Hancock <gazhank@gmail.com>