### PR TITLE
docs: update a few parsers

### DIFF
--- a/docs/api-binding-mock.md
+++ b/docs/api-binding-mock.md
@@ -3,6 +3,8 @@ id: api-binding-mock
 title: 📦 @serialport/binding-mock
 ---
 
+| [npm](https://www.npmjs.com/package/@serialport/binding-mock) | [github](https://github.com/serialport/binding-mock) |
+
 ## Mock Binding
 
 ```ts
@@ -13,7 +15,7 @@ const { MockBinding } = require('@serialport/binding-mock')
 
 Testing is an important feature of any library. To aid in our own tests, we've developed a `MockBinding`, a fake hardware binding that doesn't actually need any hardware to run. This class passes all of the same tests as our hardware based bindings and provides a few additional test related interfaces.
 
-This class is ued in the [`SerialPortMock`](api-serialport.md) class if you wish to test the stream interface.
+This class is used in the [`SerialPortMock`](api-serialport.md) class if you wish to test the stream interface.
 
 ### `createPort(options: CreatePortOptions)`
 
@@ -49,6 +51,8 @@ Open a port and return it.
 ### `emitData(data: Buffer | string)`
 
 ### `serialNumber`
+
+A unique number for each port returned from `open()`
 
 ### `recording`
 

--- a/docs/api-bindings-cpp.md
+++ b/docs/api-bindings-cpp.md
@@ -2,6 +2,7 @@
 id: api-binding-cpp
 title: 📦 @serialport/bindings-cpp
 ---
+| [npm](https://www.npmjs.com/package/@serialport/bindings-cpp) | [github](https://github.com/serialport/bindings-cpp) |
 
 The `Binding` is how Node-SerialPort talks to the underlying system. By default, we auto-detect Windows, Linux and OS X, and load the appropriate module for your system. You can assign `SerialPort.Binding` to any binding you like. Find more bindings by searching ["serialport-binding" at npm](https://www.npmjs.com/search?q=serialport-binding).
 

--- a/docs/api-parser-byte-length.md
+++ b/docs/api-parser-byte-length.md
@@ -1,23 +1,37 @@
 ---
 id: api-parser-byte-length
-title: 📦 ByteLength Parser
+title: 📦 parser-byte-length
 ---
+| [npm](https://www.npmjs.com/package/@serialport/parser-byte-length) | [github](https://github.com/serialport/node-serialport/tree/master/packages/parser-byte-length) |
+
+## Byte Length Parser
+
 ```ts
-new ByteLength(options)
+import { ByteLengthParser } from '@serialport/parser-byte-length'
+// or
+const { ByteLengthParser } = require('@serialport/parser-byte-length')
 ```
+
 Emit data every number of bytes.
 
 A transform stream that emits data as a buffer after a specific number of bytes are received. Runs in O(n) time.
 
-Arguments
-- `options.length: number` the number of bytes to be emitted on each data event
+### Constructor Arguments
 
-## Example
-```js
+```ts
+interface ByteLengthOptions extends TransformOptions {
+  /** the number of bytes on each data event */
+  length: number
+}
+```
+
+### Example
+
+```ts
 const { SerialPort } = require('serialport')
-const ByteLength = require('@serialport/parser-byte-length')
+const { ByteLengthParser } = require('@serialport/parser-byte-length')
 const port = new SerialPort({ path: '/dev/ROBOT', baudRate: 14400 })
 
-const parser = port.pipe(new ByteLength({length: 8}))
+const parser = port.pipe(new ByteLengthParser({ length: 8 }))
 parser.on('data', console.log) // will have 8 bytes per data event
 ```

--- a/docs/api-parser-cctalk.md
+++ b/docs/api-parser-cctalk.md
@@ -1,18 +1,33 @@
 ---
 id: api-parser-cctalk
-title: 📦 ccTalk Parser
+title: 📦 parser-cctalk
 ---
-```js
-new CCTalk()
+
+| [npm](https://www.npmjs.com/package/@serialport/parser-cctalk) | [github](https://github.com/serialport/node-serialport/tree/master/packages/parser-cctalk) |
+
+## CCTalk Parser
+
+```ts
+import { CCTalkParser } from '@serialport/parser-cctalk'
+// or
+const { CCTalkParser } = require('@serialport/parser-cctalk')
 ```
+
 A transform stream that emits [ccTalk](https://en.wikipedia.org/wiki/CcTalk) packets as they are received.
 
-## Example
-```js
+### Constructor Argument
+
+```ts
+maxDelayBetweenBytesMs: number = 50
+```
+
+### Example
+
+```ts
 const { SerialPort } = require('serialport')
-const CCTalk = require('@serialport/parser-cctalk')
+const { CCTalkParser } = require('@serialport/parser-cctalk')
 const port = new SerialPort({ path: '/dev/ROBOT', baudRate: 14400 })
 
-const parser = port.pipe(new CCTalk())
-parser.on('data', console.log)
+const parser = port.pipe(new CCTalkParser(100))
+parser.on('data', console.log) // emits a buffer with a complete CCTalk packet
 ```

--- a/docs/api-parser-delimiter.md
+++ b/docs/api-parser-delimiter.md
@@ -1,26 +1,37 @@
 ---
 id: api-parser-delimiter
-title: 📦 Delimiter Parser
+title: 📦 parser-delimiter
 ---
+| [npm](https://www.npmjs.com/package/@serialport/parser-delimiter) | [github](https://github.com/serialport/node-serialport/tree/master/packages/parser-delimiter) |
+
+## Delimiter Parser
+
 ```ts
-new Delimiter(options: {
-  delimiter: string | Buffer | number[],
-  includeDelimiter: boolean
-})
+import { DelimiterParser } from '@serialport/parser-delimiter'
+// or
+const { DelimiterParser } = require('@serialport/parser-delimiter')
 ```
 
 A transform stream that emits data each time a byte sequence is received. To use the `Delimiter` parser, provide a delimiter as a string, buffer, or array of bytes. Runs in O(n) time.
 
-Arguments
-- `options.delimiter: string|Buffer|number[]` The delimiter on which to split incoming data.
-- `options.includeDelimiter: boolean` Indicate if the delimiter itself should be included in the emitted data. Defaults to `false`
+### Constructor Arguments
 
+```ts
+interface DelimiterOptions extends TransformOptions {
+  /** The delimiter on which to split incoming data. */
+  delimiter: string | Buffer | number[]
+  /** Should the delimiter be included at the end of data. Defaults to `false` */
+  includeDelimiter?: boolean
+}
+```
 
-```js
+### Example
+
+```ts
 const { SerialPort } = require('serialport')
-const Delimiter = require('@serialport/parser-delimiter')
+const { DelimiterParser } = require('@serialport/parser-delimiter')
 const port = new SerialPort({ path: '/dev/ROBOT', baudRate: 14400 })
 
-const parser = port.pipe(new Delimiter({ delimiter: '\n' }))
+const parser = port.pipe(new DelimiterParser({ delimiter: '\n' }))
 parser.on('data', console.log) // emits data after every '\n'
 ```


### PR DESCRIPTION
Figured out a nice way to link to npm and github, and provide arguments and the example. Also decided to drop the `@serialport/` from the sidebar as it's annoying and the 📦 icon does a good job at denoting it's a package.