### PR TITLE
docs: fix mock port emit example

### DIFF
--- a/docs/api-serialport.md
+++ b/docs/api-serialport.md
@@ -90,10 +90,14 @@ The `MockBinding` class being used by the port.
 
 ### port
 
+The port property only exists on an open port. You can't emit data when it's closed.
+
 ```ts
 SerialPortMock.binding.createPort('/dev/robot')
 const port = new SerialPortMock({ path: '/dev/robot', baudRate: 9600 })
-port.port.emitData('data')
+port.on('open', () => {
+  port.port.emitData('data')
+})
 ```
 
 The [MockPortBinding](api-binding-mock#mockportbinding) object opened for the port.

--- a/versioned_docs/version-10.x.x/api-serialport.md
+++ b/versioned_docs/version-10.x.x/api-serialport.md
@@ -90,10 +90,14 @@ The `MockBinding` class being used by the port.
 
 ### port
 
+The port property only exists on an open port. You can't emit data when it's closed.
+
 ```ts
 SerialPortMock.binding.createPort('/dev/robot')
 const port = new SerialPortMock({ path: '/dev/robot', baudRate: 9600 })
-port.port.emitData('data')
+port.on('open', () => {
+  port.port.emitData('data')
+})
 ```
 
 The [MockPortBinding](api-binding-mock#mockportbinding) object opened for the port.


### PR DESCRIPTION
Had a bad example reported in https://github.com/serialport/node-serialport/issues/2432