### PR TITLE
Add rts-mode to docs as a windows extension on open options

### DIFF
--- a/docs/api-bindings-cpp.mdx
+++ b/docs/api-bindings-cpp.mdx
@@ -180,6 +180,8 @@ interface LinuxOpenOptions extends OpenOptions {
 interface WindowsOpenOptions extends OpenOptions {
   /** Device parity defaults to none */
   parity?: 'none' | 'even' | 'odd' | 'mark' | 'space'
+  /** RTS mode defaults to handshake */
+  rtsMode?: 'handshake' | 'enable' | 'toggle'
 }
 ```
 

--- a/versioned_docs/version-10.x.x/api-bindings-cpp.mdx
+++ b/versioned_docs/version-10.x.x/api-bindings-cpp.mdx
@@ -180,6 +180,8 @@ interface LinuxOpenOptions extends OpenOptions {
 interface WindowsOpenOptions extends OpenOptions {
   /** Device parity defaults to none */
   parity?: 'none' | 'even' | 'odd' | 'mark' | 'space'
+  /** RTS mode defaults to handshake */
+  rtsMode?: 'handshake' | 'enable' | 'toggle'
 }
 ```
 


### PR DESCRIPTION
This adds documentation required to call out the optional `rtsMode` windows-only extension to the `OpenOptions` for the `bindings-cpp` (https://github.com/serialport/bindings-cpp/pull/23). Looks good when rendered locally:
![image](https://user-images.githubusercontent.com/34520007/156055404-e9e4151c-2d0a-4387-9f78-852f93c0eb0f.png)
