### PR TITLE
Fix example in mock documentation

### DIFF
--- a/docs/api-binding-mock.md
+++ b/docs/api-binding-mock.md
@@ -80,6 +80,7 @@ port.lastWrite // null | Buffer
 ```ts
 const { MockBinding } = require('@serialport/binding-mock')
 const { SerialPortStream } = require('@serialport/stream')
+const {ReadlineParser} = require("@serialport/parser-readline");
 
 // Create a port and enable the echo and recording.
 MockBinding.createPort('/dev/ROBOT', { echo: true, record: true })
@@ -87,7 +88,7 @@ const port = new SerialPortStream({ binding: MockBinding, path: '/dev/ROBOT', ba
 
 /* Add some action for incoming data. For example,
 ** print each incoming line in uppercase */
-const parser = new Readline()
+const parser = new ReadlineParser()
 port.pipe(parser).on('data', line => {
   console.log(line.toUpperCase())
 })
@@ -95,7 +96,7 @@ port.pipe(parser).on('data', line => {
 // wait for port to open...
 port.on('open', () => {
   // ...then test by simulating incoming data
-  port.binding.emitData("Hello, world!\n")
+  port.port.emitData("Hello, world!\n")
 })
 
 /* Expected output:

--- a/versioned_docs/version-10.x.x/api-binding-mock.md
+++ b/versioned_docs/version-10.x.x/api-binding-mock.md
@@ -80,6 +80,7 @@ port.lastWrite // null | Buffer
 ```ts
 const { MockBinding } = require('@serialport/binding-mock')
 const { SerialPortStream } = require('@serialport/stream')
+const {ReadlineParser} = require("@serialport/parser-readline");
 
 // Create a port and enable the echo and recording.
 MockBinding.createPort('/dev/ROBOT', { echo: true, record: true })
@@ -87,7 +88,7 @@ const port = new SerialPortStream({ binding: MockBinding, path: '/dev/ROBOT', ba
 
 /* Add some action for incoming data. For example,
 ** print each incoming line in uppercase */
-const parser = new Readline()
+const parser = new ReadlineParser()
 port.pipe(parser).on('data', line => {
   console.log(line.toUpperCase())
 })
@@ -95,7 +96,7 @@ port.pipe(parser).on('data', line => {
 // wait for port to open...
 port.on('open', () => {
   // ...then test by simulating incoming data
-  port.binding.emitData("Hello, world!\n")
+  port.port.emitData("Hello, world!\n")
 })
 
 /* Expected output:


### PR DESCRIPTION
Looks like a few minor API changes broke the example in the documentation.  Should be fixed here.