### PR TITLE
Add friendlyName to PortInfo interface 

### DIFF
--- a/docs/api-bindings-cpp.mdx
+++ b/docs/api-bindings-cpp.mdx
@@ -61,6 +61,7 @@ interface PortInfo {
     locationId: string | undefined;
     productId: string | undefined;
     vendorId: string | undefined;
+    friendlyName?: string | undefined;
 }
 
 function list(): Promise<PortInfo>

--- a/versioned_docs/version-10.x.x/api-bindings-cpp.mdx
+++ b/versioned_docs/version-10.x.x/api-bindings-cpp.mdx
@@ -61,6 +61,7 @@ interface PortInfo {
     locationId: string | undefined;
     productId: string | undefined;
     vendorId: string | undefined;
+    friendlyName?: string | undefined;
 }
 
 function list(): Promise<PortInfo>


### PR DESCRIPTION
Update documentation per fix for https://github.com/serialport/node-serialport/issues/2600

Adds `friendlyName` (Windows specific property) to Port definition