### PR TITLE
Add friendlyName and lowLatency to interfaces

### DIFF
--- a/docs/api-binding-mock.md
+++ b/docs/api-binding-mock.md
@@ -27,7 +27,7 @@ interface CreatePortOptions {
   manufacturer?: string;
   vendorId?: string;
   productId?: string;
-  friendlyName?: string;
+  friendlyName: string;
 }
 
 // Create a port and enable the echo and recording.

--- a/docs/api-binding-mock.md
+++ b/docs/api-binding-mock.md
@@ -27,6 +27,7 @@ interface CreatePortOptions {
   manufacturer?: string;
   vendorId?: string;
   productId?: string;
+  friendlyName?: string;
 }
 
 // Create a port and enable the echo and recording.

--- a/docs/api-bindings-cpp.mdx
+++ b/docs/api-bindings-cpp.mdx
@@ -61,6 +61,7 @@ interface PortInfo {
     locationId: string | undefined;
     productId: string | undefined;
     vendorId: string | undefined;
+    friendlyName: string | undefined;
 }
 
 function list(): Promise<PortInfo>
@@ -78,7 +79,8 @@ const ports = await LinuxBinding.list()
 //   pnpId: 'usb-Arduino__www.arduino.cc__0043_752303138333518011C1-if00',
 //   locationId: undefined,
 //   productId: '0043',
-//   vendorId: '2341'
+//   vendorId: '2341',
+//   friendlyName: undefined
 // }]
 ```
 
@@ -94,7 +96,8 @@ const ports = await WindowsBinding.list()
 //   pnpId: 'USB\\VID_2341&PID_0043\\752303138333518011C1',
 //   locationId: 'Port_#0003.Hub_#0001',
 //   productId: '0043',
-//   vendorId: '2341'
+//   vendorId: '2341',
+//   friendlyName: 'USB Serial Device (COM3)'
 // }]
 ```
 
@@ -110,7 +113,8 @@ const ports = await DarwinBinding.list()
 //   pnpId: undefined,
 //   locationId: '14500000',
 //   productId: '0043',
-//   vendorId: '2341'
+//   vendorId: '2341',
+//   friendlyName: undefined
 // }]
 ```
 

--- a/versioned_docs/version-10.x.x/api-binding-mock.md
+++ b/versioned_docs/version-10.x.x/api-binding-mock.md
@@ -27,6 +27,7 @@ interface CreatePortOptions {
   manufacturer?: string;
   vendorId?: string;
   productId?: string;
+  friendlyName: string;
 }
 
 // Create a port and enable the echo and recording.

--- a/versioned_docs/version-10.x.x/api-bindings-cpp.mdx
+++ b/versioned_docs/version-10.x.x/api-bindings-cpp.mdx
@@ -61,6 +61,7 @@ interface PortInfo {
     locationId: string | undefined;
     productId: string | undefined;
     vendorId: string | undefined;
+    friendlyName: string | undefined;
 }
 
 function list(): Promise<PortInfo>
@@ -78,7 +79,8 @@ const ports = await LinuxBinding.list()
 //   pnpId: 'usb-Arduino__www.arduino.cc__0043_752303138333518011C1-if00',
 //   locationId: undefined,
 //   productId: '0043',
-//   vendorId: '2341'
+//   vendorId: '2341',
+//   friendlyName: undefined
 // }]
 ```
 
@@ -94,7 +96,8 @@ const ports = await WindowsBinding.list()
 //   pnpId: 'USB\\VID_2341&PID_0043\\752303138333518011C1',
 //   locationId: 'Port_#0003.Hub_#0001',
 //   productId: '0043',
-//   vendorId: '2341'
+//   vendorId: '2341',
+//   friendlyName: 'USB Serial Device (COM3)'
 // }]
 ```
 
@@ -110,7 +113,8 @@ const ports = await DarwinBinding.list()
 //   pnpId: undefined,
 //   locationId: '14500000',
 //   productId: '0043',
-//   vendorId: '2341'
+//   vendorId: '2341',
+//   friendlyName: undefined
 // }]
 ```
 

--- a/versioned_docs/version-10.x.x/bin-repl.md
+++ b/versioned_docs/version-10.x.x/bin-repl.md
@@ -39,7 +39,8 @@ globals { SerialPort, SerialPortMock, path, port }
     pnpId: undefined,
     locationId: '02100000',
     vendorId: '2341',
-    productId: '8036'
+    productId: '8036',
+    friendlyName: undefined
   }
 ]
 > port.open()


### PR DESCRIPTION
Alternative fix for https://github.com/serialport/node-serialport/issues/2600

Add friendlyName to PortInfo, and LowLatency to PortStatus